### PR TITLE
Use index-digest v1.5.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   index-digest-version:
     description: "The version of index-digest to install"
     required: true
-    default: "1.5.0"
+    default: "1.5.1"
     
   index-digest-dsn:
     description: "DSN pointing at the database to check"


### PR DESCRIPTION
Use the latest index-digest by default. Its container is now Alpine-based (hence smaller) and uses the latest Python 3.10.

https://github.com/macbre/index-digest/releases/tag/v1.5.1